### PR TITLE
Use mysql procedures for isvdomain and lookup

### DIFF
--- a/templates/postfix/mysql-aliases.cf.j2
+++ b/templates/postfix/mysql-aliases.cf.j2
@@ -11,14 +11,4 @@ user = {{ mailserver_db_mysql_user }}
 password = {{ mailserver_db_mysql_password }}
 dbname = {{ mailserver_db_mysql_db }}
 
-# Use stored procedure for performance reasons
-# We want do do this:
-# query = CALL lookup('%u', '%d')
-# Because the designers of Postfix did not really get how the MySQL C API works
-# and they do not show interest in fixing it, this results in the following error:
-# postfix/cleanup[9883]: warning: mysql query failed: Commands out of sync; you can't run this command now
-# For more details, look here: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=794496
-# Therefore, we need to change the PROCEDURE to a FUNCTION and we have to do this:
-query = SELECT retval FROM (SELECT lookup('%u', '%d') AS retval) t WHERE t.retval IS NOT NULL;
-
-require_result_set = no
+query = CALL lookup('%u', '%d');

--- a/templates/postfix/mysql-vdomains.cf.j2
+++ b/templates/postfix/mysql-vdomains.cf.j2
@@ -9,7 +9,4 @@ user = {{ mailserver_db_mysql_user }}
 password = {{ mailserver_db_mysql_password }}
 dbname = {{ mailserver_db_mysql_db }}
 
-# Use stored procedure for performance reasons, see mysql-aliases.cf for rant
-query = SELECT retval FROM (SELECT isvdomain('%s') AS retval) t WHERE t.retval IS NOT NULL;
-
-require_result_set = no
+query = CALL isvdomain('%s');


### PR DESCRIPTION
Since postfix 3.2 stored procedures are supported.

Sample stored procs:
```SQL
CREATE
    definer = root@localhost procedure isvdomain(IN arg varchar(255))
BEGIN
    SELECT GROUP_CONCAT(DISTINCT `domain` SEPARATOR ' ') FROM `alias` WHERE domain = arg AND domain != 'tsos.ethz.ch';
END;
```
```SQL
CREATE
    definer = root@localhost procedure lookup(IN username varchar(255), IN domainname varchar(255))
BEGIN
    IF EXISTS(SELECT * FROM `alias` WHERE `name` = username AND `domain` = domainname) THEN
        SELECT GROUP_CONCAT(CONCAT_WS('@', `destname`, `destdomain`) SEPARATOR ' ')
        FROM `alias`
        WHERE `name` = username
          AND `domain` = domainname;
    ELSE
        SELECT GROUP_CONCAT(CONCAT_WS('@', username, `destdomain`) SEPARATOR ' ')
        FROM `alias`
        where `name` = '*'
          AND `domain` = domainname;
    END IF;
END;


```