### PR TITLE
Add map of allowed proxy servers for submission

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,10 @@ mailserver_behind_proxy: True
 # The form [hostname] turns off MX lookups
 mailserver_proxy: ""
 
+# Proxy server hostnames which are allowed to submit unauthenticated mail.
+# All other hosts have to authenticate to be accepted.
+mailserver_allowed_proxies: []
+
 # Rate limis
 mailserver_message_size_limit: 52428800 # 50 MB
 mailserver_connection_rate_limit: 30

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,6 +7,12 @@
       state: restarted
       daemon_reload: yes
 
+  - name: rebuild proxy map
+    become: True
+    command: postmap /etc/postfix/allowed_proxies
+    notify:
+      - restart postfix
+
   - name: restart dovecot
     become: True
     systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -116,6 +116,19 @@
       - restart postfix
     tags: postfix
 
+  - name: Configure allowed proxy map
+    become: True
+    template:
+      src: postfix/allowed_proxies.j2
+      dest: /etc/postfix/allowed_proxies
+      owner: root
+      group: root
+      mode: 0644
+    notify:
+      - rebuild proxy map
+    tags:
+      - postfix
+
   - name: Handle TLS
     include: tls.yml
 

--- a/templates/postfix/allowed_proxies.j2
+++ b/templates/postfix/allowed_proxies.j2
@@ -1,0 +1,3 @@
+{% for proxy in mailserver_allowed_proxies %}
+{{ proxy }} OK
+{% endfor %}

--- a/templates/postfix/main.cf.j2
+++ b/templates/postfix/main.cf.j2
@@ -173,14 +173,16 @@ bounce_queue_lifetime=1d
 smtpd_sender_restrictions = reject_sender_login_mismatch,
   permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination,
   reject_non_fqdn_sender, reject_non_fqdn_recipient, reject_unknown_recipient_domain,
-  reject_unauth_pipelining, permit
+  reject_unauth_pipelining, check_client_access hash:/etc/postfix/allowed_proxies,
+  reject
 
 # smtp destination restrictions
 # Either you're authenticated OR you are from 127.0.0.1 OR you satisfy a boatload of constraints
 # Also note that the same thing ist in master.cf without sasl restrictions
 smtpd_recipient_restrictions = reject_sender_login_mismatch, permit_sasl_authenticated,
   permit_mynetworks, reject_unknown_recipient_domain, reject_unauth_pipelining,
-  reject_unauth_destination, reject_multi_recipient_bounce, permit
+  reject_unauth_destination, reject_multi_recipient_bounce, check_client_access hash:/etc/postfix/allowed_proxies,
+  reject
 {% else %}
 # smtpd sender restrictions
 smtpd_sender_restrictions = reject_sender_login_mismatch,


### PR DESCRIPTION
If running behind a proxy (e.g PMG) accept only from those
servers specified in mailserver_allowed_proxies unauthenticated
submission requests.
If submitting mail from another host you have to authenticate yourself.