### PR TITLE
RFC8314 compliance

### DIFF
--- a/templates/dovecot/conf.d/10-master.conf.j2
+++ b/templates/dovecot/conf.d/10-master.conf.j2
@@ -20,7 +20,7 @@ default_internal_user = dovecot
 
 service imap-login {
   inet_listener imap {
-    port = 143
+    port = 0
   }
   inet_listener imaps {
     port = 993
@@ -42,7 +42,7 @@ service imap-login {
 {% if mailserver_enable_pop3 %}
 service pop3-login {
   inet_listener pop3 {
-    port = 110
+    port = 0
   }
   inet_listener pop3s {
     port = 995

--- a/templates/dovecot/dovecot.conf.j2
+++ b/templates/dovecot/dovecot.conf.j2
@@ -24,8 +24,7 @@
 # options. The paths listed here are for configure --prefix=/usr
 # --sysconfdir=/etc --localstatedir=/var
 
-# Enable installed protocols
-!include_try /usr/share/dovecot/protocols.d/*.protocol
+protocols = imap lmtp sieve {{ 'pop3' if mailserver_enable_pop3 else '' }}
 
 # Listen everywhere
 listen = *, ::


### PR DESCRIPTION
To comply with [RFC8314](https://tools.ietf.org/html/rfc8314) disable port 143 (IMAP) and 110 (POP3) and thus STARTTLS for those protocols.

Standard compliant protocol usage is as follows:

  * IMAP: SSL/TLS over port **993** (IMAPS)
  * POP3: SSL/TLS over port **995** (POP3S)
  * SMTP (submission only): SSL/TLS over port **465**. The standard acknowledges that STARTTLS is still quite popular for SMTP submission over port 587. Thus this remains enabled for a transition period.